### PR TITLE
[Documentation] Example of how to add a pass to a CIRCT Dialect

### DIFF
--- a/include/circt/Dialect/FIRRTL/Passes.h
+++ b/include/circt/Dialect/FIRRTL/Passes.h
@@ -174,6 +174,8 @@ std::unique_ptr<mlir::Pass> createLowerGroupsPass();
 
 std::unique_ptr<mlir::Pass> createGroupSinkPass();
 
+std::unique_ptr<mlir::Pass> createFooWiresPass();
+
 /// Generate the code for registering passes.
 #define GEN_PASS_REGISTRATION
 #include "circt/Dialect/FIRRTL/Passes.h.inc"

--- a/include/circt/Dialect/FIRRTL/Passes.td
+++ b/include/circt/Dialect/FIRRTL/Passes.td
@@ -782,4 +782,16 @@ def ProbeDCE : Pass<"firrtl-probe-dce", "firrtl::CircuitOp"> {
   ];
 }
 
+def FooWires : Pass<"firrtl-foo-wires", "firrtl::CircuitOp"> {
+  let summary = "Change all wires' name to foo_<n>.";
+  let description = [{
+    Very basic pass that numbers all of the wires in a given model.
+    The wires' names are then all converte to foo_<that number>.
+  }];
+  let constructor = "circt::firrtl::createFooWiresPass()";
+  let statistics = [
+    Statistic<"numChangedWires", "num-changed-wires", "Number of wires changed">
+  ];
+}
+
 #endif // CIRCT_DIALECT_FIRRTL_PASSES_TD

--- a/lib/Dialect/FIRRTL/Transforms/CMakeLists.txt
+++ b/lib/Dialect/FIRRTL/Transforms/CMakeLists.txt
@@ -11,6 +11,7 @@ add_circt_dialect_library(CIRCTFIRRTLTransforms
   ExtractInstances.cpp
   FinalizeIR.cpp
   FlattenMemory.cpp
+  FooWires.cpp
   GrandCentral.cpp
   GroupSink.cpp
   HoistPassthrough.cpp

--- a/lib/Dialect/FIRRTL/Transforms/FooWires.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/FooWires.cpp
@@ -1,0 +1,47 @@
+//===- FooWires.cpp - Flatten Memory Pass ----------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines the FooWires pass.
+//
+//===----------------------------------------------------------------------===//
+
+#include "PassDetails.h"
+#include "circt/Dialect/FIRRTL/FIRRTLAnnotations.h"
+#include "circt/Dialect/FIRRTL/FIRRTLOps.h"
+#include "circt/Dialect/FIRRTL/FIRRTLTypes.h"
+#include "circt/Dialect/FIRRTL/FIRRTLUtils.h"
+#include "circt/Dialect/FIRRTL/Passes.h"
+#include "mlir/IR/ImplicitLocOpBuilder.h"
+#include "llvm/ADT/TypeSwitch.h"
+#include "llvm/Support/Debug.h"
+#include <numeric>
+
+#define DEBUG_TYPE "lower-memory"
+
+using namespace circt;
+using namespace firrtl;
+
+namespace {
+    // A test pass that simply replaces all wire names with foo_<n>
+    struct FooWires : FooWiresBase<FooWires> {
+      void runOnOperation() override;
+    };
+}
+
+// Runs the pass when triggered by a tool or by circt-opt
+void FooWires::runOnOperation() {
+  int nWires = 0; // Counts the number of wires modified
+  getOperation().walk([&](WireOp wire) { // Walk over every wire in the module
+    wire.setName("foo_" + std::to_string(nWires)); // Rename said wire
+    nWires++;
+  });
+}
+
+std::unique_ptr<mlir::Pass> circt::firrtl::createFooWiresPass() {
+  return std::make_unique<FooWires>();
+}

--- a/lib/Firtool/Firtool.cpp
+++ b/lib/Firtool/Firtool.cpp
@@ -34,6 +34,8 @@ LogicalResult firtool::populatePreprocessTransforms(mlir::PassManager &pm,
       opt.disableAnnotationsUnknown, opt.disableAnnotationsClassless,
       opt.lowerAnnotationsNoRefTypePorts));
 
+  pm.nest<firrtl::CircuitOp>().addPass(firrtl::createFooWiresPass());
+
   return success();
 }
 


### PR DESCRIPTION
With this dud PR, I want to clearly document how one can add a new pass into CIRCT.
I have added a dummy pass to the firrtl dialect that simply renames all of the wires to foo. To do so I went through the following steps:  
   1. Create a new entry in `include/circt/Dialect/FIRRTL/Passes.td` that describes the pass giving it at least a `summary`, a `description`, and a `constructor`.    
   2. Compile CIRCT to trigger the boiler-plate generation. This will crash and tell me which functions I have to implement and where (usually only the constructor defined in the `.td` file).    
   3. Declare the constructor mentioned in the tablegen file using the same signature in `include/circt/Dialect/FIRRTL/Passes.h`.   
   4. Create a new file using the name of your pass that matches the one in the tablegen description and add it to the folder's `CMakeLists.txt`. In my case it was `lib/Dialect/FIRRTL/Transforms/FooWires.cpp`. Once this is done, implement it with the following structure:  
       -  Create a `struct` defining your pass, while inheriting from the auto-generated <PassBase> class.  
       -   Define and implement an override of the `void runOnOperation() override;` method that will contain the meat of your pass.  
       -   Implement the constructor that you declared previously.  
   5. [Optional] Add your pass where you want it to be triggered in your dialect's compile flow.  
  
Once all of this is done, your pass should run when the tool that uses it is run. If it wasn't added to a tool, then it can be added in as a flag to `circt-opt` (see `circt-opt --help` for more info).  
